### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * bump github.com/rollbar/rollbar-go from 1.4.0 to 1.4.2
 
 ## v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/errgo-rollbar
 
-go 1.16
+go 1.17
 
 require (
 	github.com/rollbar/rollbar-go v1.4.2


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.